### PR TITLE
Juniper SAAS compatibility

### DIFF
--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -16,6 +16,7 @@ from django.template import Context, Template
 from webob import Response
 
 from celery.task import task
+from fs.copy import copy_fs
 from fs.tempfs import TempFS
 from djpyfs import djpyfs
 
@@ -65,10 +66,7 @@ def updoad_all_content(temp_directory, fs):
     This standalone function handles the bulk upload of unzipped content.
     """
     if not settings.DJFS.get('type', 'osfs') == "s3fs":
-        # Temporary fix
-        # TODO: find a better solution for ImportError: No module named fs.utils
-        from fs.utils import copydir
-        copydir(temp_directory, fs, overwrite=True)
+        copy_fs(temp_directory, fs)
         return
 
     dest_dir = fs.dir_path

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -26,8 +26,6 @@ _ = lambda text: text
 
 class ScormXBlock(XBlock):
 
-    # fs = djpyfs.get_filesystem("scorm")
-
     display_name = String(
         display_name=_("Display Name"),
         help=_("Display name for this module"),
@@ -232,6 +230,12 @@ class ScormXBlock(XBlock):
         scorm_file_path = ''
         if self.scorm_file:
             scorm_file_path = fs.get_url(self.scorm_file)
+
+        # Required when working with a S3 djfs confifuguration and a proxy for the files
+        # so that the Same-origin security policy does not block the files
+        if settings.DJFS.get('use_proxy', False):
+            proxy_file = fs.get_url(self.scorm_file).split(settings.DJFS.get('prefix'))[-1]
+            scorm_file_path = "/{}{}".format(settings.DJFS.get('proxy_root'), proxy_file)
 
         return {
             'scorm_file_path': scorm_file_path,

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -40,7 +40,7 @@ def s3_upload(all_content, temp_directory, dest_dir):
     bucket = conn.get_bucket(settings.DJFS.get('bucket'))
 
     for filepath in all_content:
-        sourcepath = path.join(temp_directory.root_path, filepath)
+        sourcepath = path.normpath(path.join(temp_directory.root_path, filepath))
         destpath = path.normpath(path.join(dest_dir, filepath))
 
         k = boto.s3.key.Key(bucket)

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -46,10 +46,9 @@ def s3_upload(all_content, temp_directory, dest_dir):
     for filepath in all_content:
         sourcepath = path.normpath(path.join(temp_directory.root_path, filepath))
         destpath = path.normpath(path.join(dest_dir, filepath))
-        content_type = mimetypes.guess_type(sourcepath)[0]  # Returns a tuple
 
-        if not content_type:  # It's possible that the type is not in the mimetypes list.
-            content_type = DEFAULT_CONTENT_TYPE
+        # It's possible that the type is not in the mimetypes list.
+        content_type = mimetypes.guess_type(sourcepath)[0]  or DEFAULT_CONTENT_TYPE
 
         if isinstance(content_type, bytes):  # In some versions of Python guess_type, it returns bytes instead of str.
             content_type = content_type.decode('utf-8')
@@ -197,7 +196,7 @@ class ScormXBlock(XBlock):
             manifest_path = '{}/imsmanifest.xml'.format(temp_directory.root_path)
             with open(manifest_path, 'r') as manifest_file:
                 manifest = manifest_file.read()
-            manifest_file.closed
+
             self.set_fields_xblock(manifest)
 
             # Now the part where we copy the data fast fast fast
@@ -336,8 +335,7 @@ class ScormXBlock(XBlock):
             # By standard a namesapace it's a URI
             # we ensure the namespace we got in the tree object it's in fact a URL
             # if not we return an empty namespace and procced to look for resource tag
-            if not namespace.startswith("http"):
-                namespace = None
+            namespace = namespace if namespace.startswith("http") else None
 
             if namespace:
                 resource = tree.find('{{{0}}}resources/{{{0}}}resource'.format(namespace))

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -278,6 +278,8 @@ class ScormXBlock(XBlock):
         if settings.DJFS.get('remove_signature', False):
             scorm_file_path = urlparse.urljoin(scorm_file_path, urlparse.urlparse(scorm_file_path).path)
 
+        scorm_file_path = urlparse.unquote(scorm_file_path)
+
         return {
             'scorm_file_path': scorm_file_path,
             'lesson_score': self.lesson_score,

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import json
 import re
 import pkg_resources
 import zipfile
 import xml.etree.ElementTree as ET
-import urlparse
+from urllib.parse import urljoin, urlparse, unquote
 import boto
 
 from os import path, walk
@@ -194,7 +193,7 @@ class ScormXBlock(XBlock):
             # Destroy temp directory after all files are copied.
             temp_directory.close()
 
-        return Response(json.dumps({'result': 'success'}), content_type='application/json')
+        return Response({'result': 'success'}, content_type='application/json')
 
     @XBlock.json_handler
     def scorm_get_value(self, data, suffix=''):
@@ -294,9 +293,9 @@ class ScormXBlock(XBlock):
             scorm_file_path = "/{}{}".format(settings.DJFS.get('proxy_root'), proxy_file)
 
         if settings.DJFS.get('remove_signature', False):
-            scorm_file_path = urlparse.urljoin(scorm_file_path, urlparse.urlparse(scorm_file_path).path)
+            scorm_file_path = urljoin(scorm_file_path, urlparse(scorm_file_path).path)
 
-        scorm_file_path = urlparse.unquote(scorm_file_path)
+        scorm_file_path = unquote(scorm_file_path)
 
         return {
             'scorm_file_path': scorm_file_path,

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -30,7 +30,7 @@ _ = lambda text: text
 FILES_THRESHOLD_FOR_ASYNC = 150
 
 
-@task()
+@task(name=u'scormxblock.scormxblock.s3_upload', routing_key=settings.HIGH_PRIORITY_QUEUE)
 def s3_upload(all_content, temp_directory, dest_dir):
     """
     Actual handling of the s3 uploads.
@@ -70,7 +70,7 @@ def updoad_all_content(temp_directory, fs):
         s3_upload(all_content, temp_directory, dest_dir)
     else:
         # The raw number of files is going to make this request time out. Use celery instead
-        s3_upload.delay(all_content, temp_directory, dest_dir)
+        s3_upload.apply_async((all_content, temp_directory, dest_dir), serializer='pickle')
 
 
 class ScormXBlock(XBlock):

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -59,7 +59,7 @@ def updoad_all_content(temp_directory, fs):
         copydir(temp_directory, fs, overwrite=True)
         return
 
-    dest_dir = fs._s3path("")
+    dest_dir = fs.dir_path
     all_content = []
     for dir_, _, files in walk(temp_directory.root_path):
         for filename in files:

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -272,7 +272,7 @@ class ScormXBlock(XBlock):
         # Required when working with a S3 djfs confifuguration and a proxy for the files
         # so that the Same-origin security policy does not block the files
         if settings.DJFS.get('use_proxy', False):
-            proxy_file = fs.get_url(self.scorm_file).split(settings.DJFS.get('prefix'))[-1]
+            proxy_file = scorm_file_path.split(settings.DJFS.get('prefix'))[-1]
             scorm_file_path = "/{}{}".format(settings.DJFS.get('proxy_root'), proxy_file)
 
         if settings.DJFS.get('remove_signature', False):

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -17,7 +17,6 @@ from webob import Response
 
 from celery.task import task
 from fs.tempfs import TempFS
-from fs.utils import copydir
 from djpyfs import djpyfs
 
 from xblock.core import XBlock
@@ -54,6 +53,9 @@ def updoad_all_content(temp_directory, fs):
     This standalone function handles the bulk upload of unzipped content.
     """
     if not settings.DJFS.get('type', 'osfs') == "s3fs":
+        # Temporary fix
+        # TODO: find a better solution for ImportError: No module named fs.utils
+        from fs.utils import copydir
         copydir(temp_directory, fs, overwrite=True)
         return
 

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -26,7 +26,7 @@ from xblock.fragment import Fragment
 
 # Make '_' a no-op so we can scrape strings
 _ = lambda text: text
-FILES_THRESHOLD_FOR_ASYNC = 150
+FILES_THRESHOLD_FOR_ASYNC = getattr(settings, 'SCORMXBLOCK_ASYNC_THRESHOLD', 150)
 
 
 @task(name=u'scormxblock.scormxblock.s3_upload', routing_key=settings.HIGH_PRIORITY_QUEUE)

--- a/scormxblock/static/html/author_view.html
+++ b/scormxblock/static/html/author_view.html
@@ -1,3 +1,11 @@
 <div class="scormxblock_block">
-    <p>Look in LMS</p>
+    <p>The SCORM module will only be rendered at the LMS</p>
+
+    <ul class="list-input settings-list">
+        <li class="field comp-setting-entry">
+            <label class="label setting-label" for="scorm_file_path">Scorm File Path (Information only):</label>
+            <input type="text" id="scorm_file_path" name="scorm_file_path" value="{{ scorm_file_path }}" disabled="disabled" style="display: block; width: 400px;">
+        </li>
+    </ul>
+
 </div>

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,13 @@
+[bumpversion]
+current_version = 0.1.0
+commit = True
+tag = True
+
+[metadata]
+description-file = README.markdown
+
+[nosetests]
+cover-package = scormxblock
+cover-tests = 1
+
+[bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='scormxblock-xblock',
-    version='0.1',
+    version='0.1.0',
     description='scormxblock XBlock',   # TODO: write a better description.
     packages=[
         'scormxblock',


### PR DESCRIPTION
This PR takes the last [commit](https://github.com/eduNEXT/edx_xblock_scorm/commits/aeb116a33987225ea0da6d38f133a807f1846d66) used as a [requirement](https://github.com/eduNEXT/edunext-platform/blob/9990b24c2b7b036d5a130b8a76e56e9b0c4068c2/requirements/edunext/base.txt#L28) in Ironwood and adds on top of it:

Taken from Pearson-Advance fork:
* Add Juniper compatibility
* Update boto to boto3
* Add a file for versioning
