### PR TITLE
CEPH Compatibility

### DIFF
--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -36,13 +36,14 @@ def s3_upload(all_content, temp_directory, dest_dir):
     """
     Actual handling of the s3 uploads.
     """
-    session = boto3.Session(
-        aws_access_key_id=settings.DJFS.get('aws_access_key_id'),
-        aws_secret_access_key=settings.DJFS.get('aws_secret_access_key'),
-        region_name=settings.DJFS.get('region_name'),
+    s3 = boto3.resource('s3',
+                        aws_access_key_id=settings.DJFS.get('aws_access_key_id'),
+                        aws_secret_access_key=settings.DJFS.get('aws_secret_access_key'),
+                        endpoint_url=settings.DJFS.get('endpoint_url'),
+                        region_name=settings.DJFS.get('region_name'),
     )
-    s3_client = session.resource('s3')
-    bucket = s3_client.Bucket(settings.DJFS.get('bucket'))
+
+    bucket = s3.Bucket(settings.DJFS.get('bucket'))
 
     for filepath in all_content:
         sourcepath = path.normpath(path.join(temp_directory.root_path, filepath))


### PR DESCRIPTION
Adding ceph compatibility to scorm, using [CEPH S3 Examples](https://github.com/ronaldddilley/ceph-s3-examples/blob/019140a534a56e8321d57bd2a8a09a210307ea2b/ceph-create-bucket.py#L26) as a reference point.

boto3 documentation:
[Service Resource](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#service-resource)
[Service Resource Bucket](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.ServiceResource.Bucket)
[S3.Bucket](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Bucket)
[Bucket.upload_file](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Bucket.upload_file)